### PR TITLE
v2 compatibilty updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-override CFLAGS += --std=c99 -O2 -Wall -Wtype-limits
+override CFLAGS += --std=c99 -O2 -Wall -Wtype-limits -Wno-missing-braces
 LDFLAGS += -lcurl -lbluetooth -lpopt
 
 SRC = ttblue.c \

--- a/python/ttblue.py
+++ b/python/ttblue.py
@@ -249,7 +249,7 @@ try:
             print tt_delete_file(p, fileno)
 
     if 1:
-        gqf = requests.get('http://gpsquickfix.services.tomtom.com/fitness/sifgps.f2p3enc.ee?timestamp=%d' % time.time()).content
+        gqf = requests.get('https://gpsquickfix.services.tomtom.com/fitness/sifgps.f2p3enc.ee?timestamp=%d' % time.time()).content
         print "Sending QuickGPSFix update (%d bytes)..." % len(gqf)
         tt_delete_file(p, 0x00020002)
         tt_write_file(p, 0x00020002, 'GPSQuickFix…')

--- a/tt_bluetooth.md
+++ b/tt_bluetooth.md
@@ -127,6 +127,9 @@ Service: UUID=b993bf91-81e1-11e4-b4a9-0800200c9a66, handles=0x30 to 0xffff
 
 ### File transfer service
 
+Handles written as 0xF1/0xF2 are for v1 and v2 watches,
+written as {handle v1}/{handle v2}.
+
 ```
 Service: UUID=b993bf90-81e1-11e4-b4a9-0800200c9a66, handles=0x23 to 0x2f
   Char: UUID=170d0d31-4213-11e3-aa6e-0800200c9a66, handle=0x25/0x72

--- a/tt_bluetooth.md
+++ b/tt_bluetooth.md
@@ -183,6 +183,8 @@ between different versions of the official TomTom MySports apps.
 
     01 13 00 00 01 12 00 00 [ TomTom Mysports Android app, older version ]
     01 13 00 00 01 1f 00 00 [ TomTom Mysports Android app, version 2.0.12-58b77f0 ]
+    01 19 00 00 01 13 00 00 [ TomTom Mysports Android app, some version a few months older than 10.0.2 ]
+    01 19 00 00 01 17 00 00 [ TomTom Mysports Android app, version 10.0.2-535 ]
 
 ### Initial pairing
 

--- a/tt_bluetooth.md
+++ b/tt_bluetooth.md
@@ -129,21 +129,21 @@ Service: UUID=b993bf91-81e1-11e4-b4a9-0800200c9a66, handles=0x30 to 0xffff
 
 ```
 Service: UUID=b993bf90-81e1-11e4-b4a9-0800200c9a66, handles=0x23 to 0x2f
-  Char: UUID=170d0d31-4213-11e3-aa6e-0800200c9a66, handle=0x25
+  Char: UUID=170d0d31-4213-11e3-aa6e-0800200c9a66, handle=0x25/0x72
     properties => NOTIFY,READ,WRITE NO RESPONSE,WRITE
-  Char: UUID=170d0d32-4213-11e3-aa6e-0800200c9a66, handle=0x28
+  Char: UUID=170d0d32-4213-11e3-aa6e-0800200c9a66, handle=0x28/0x75
     properties => NOTIFY,READ,WRITE NO RESPONSE
-  Char: UUID=170d0d33-4213-11e3-aa6e-0800200c9a66, handle=0x2b
+  Char: UUID=170d0d33-4213-11e3-aa6e-0800200c9a66, handle=0x2B/0x78
     properties => NOTIFY,READ,WRITE NO RESPONSE
-  Char: UUID=170d0d34-4213-11e3-aa6e-0800200c9a66, handle=0x2e
+  Char: UUID=170d0d34-4213-11e3-aa6e-0800200c9a66, handle=0x2E/0x7B
     properties => NOTIFY,READ,WRITE NO RESPONSE
 ```
 
-* `CH_CMD_STATUS` (handle `0x25`: used to send commands to the
+* `CH_CMD_STATUS` (handle `0x25/0x72`: used to send commands to the
   device and for the device to signal successful start/finish.
-* `CH_LENGTH ` (handle `0x28`): used to indicate the size in bytes of files transferred to/from the device.
-* `CH_TRANSFER` (handle `0x2B`): used to transfer bulk data (file contents) to/from the device.
-* `CH_CHECK` (handle `0x2E`): used to acknowledge successful receipt of data by the watch or host, depending on direction of data transfer.
+* `CH_LENGTH ` (handle `0x28/0x75`): used to indicate the size in bytes of files transferred to/from the device.
+* `CH_TRANSFER` (handle `0x2B/0x78`): used to transfer bulk data (file contents) to/from the device.
+* `CH_CHECK` (handle `0x2E/0x7B`): used to acknowledge successful receipt of data by the watch or host, depending on direction of data transfer.
 
 #### Standard GATT services
 
@@ -313,7 +313,7 @@ becomes `91 01 00`).
 #### Read from file
 
 * This is the same as the write sequence with the direction of
-  reads/writes to handles `0x28`, `0x2b`, and `0x2e` reversed.
+  reads/writes to handles `0x28/0x75`, `0x2B/0x78`, and `0x2E/0x7B` reversed.
 * The host should compute the CRC16 of bytes as they are received and
   send a sequentially increasing `ack_counter` (0, 1, 2) at the end of
   each batch of 256 packets, or partial fraction thereof at the end.

--- a/ttblue.c
+++ b/ttblue.c
@@ -317,7 +317,7 @@ int main(int argc, const char **argv)
 {
     int devid, dd, fd;
     bdaddr_t src_addr, dst_addr = {0};
-    uint8_t dst_bdaddr_type;
+    uint8_t dst_bdaddr_type = {0};
     int needs_reboot = false, success = false;
     int write_delay;
     TTDEV *ttd;

--- a/ttblue.c
+++ b/ttblue.c
@@ -226,15 +226,14 @@ time_t
 read_gqf_status(TTDEV *ttd, int debug)
 {
     time_t last_update = 0;
-    uint32_t fileno = 0x00020001;
     uint8_t *fbuf;
     int length;
-    if ((length=tt_read_file(ttd, fileno, debug, &fbuf)) < 0) {
-        fprintf(stderr, "WARNING: Could not read GPS status file 0x%08x from watch.\n", fileno);
+    if ((length=tt_read_file(ttd, ttd->files->gps_status, debug, &fbuf)) < 0) {
+        fprintf(stderr, "WARNING: Could not read GPS status file 0x%08x from watch.\n", ttd->files->gps_status);
         last_update = -1;
     } else {
 #ifdef DUMP_0x00020001
-        save_buf_to_file(make_tt_filename(fileno, "bin"), "wxb", fbuf, length, 2, true);
+        save_buf_to_file(make_tt_filename(ttd->files->gps_status, "bin"), "wxb", fbuf, length, 2, true);
 #endif
         if (length > 6 && (fbuf[0x02] | fbuf[0x03] | fbuf[0x04] | fbuf[0x05]) != 0) {
             struct tm tmp = { .tm_mday = fbuf[0x05], .tm_mon = fbuf[0x04]-1, .tm_year = (((int)fbuf[0x02])<<8) + fbuf[0x03] - 1900 };
@@ -529,25 +528,23 @@ int main(int argc, const char **argv)
         int length;
 
         fprintf(stderr, "Setting PHONE menu to '%s'.\n", hostname);
-        tt_delete_file(ttd, 0x00020002);
-        tt_write_file(ttd, 0x00020002, false, (uint8_t*)hostname, strlen(hostname), write_delay);
+        tt_delete_file(ttd, ttd->files->hostname);
+        tt_write_file(ttd, ttd->files->hostname, false, (uint8_t*)hostname, strlen(hostname), write_delay);
 
 #ifdef DUMP_0x000f20000
-        uint32_t fileno = 0x000f20000;
         fprintf(stderr, "Reading preference file 0x%08x from watch...\n", fileno);
-        if ((length=tt_read_file(ttd, fileno, debug, &fbuf)) < 0) {
+        if ((length=tt_read_file(ttd, ttd->files->manifest, debug, &fbuf)) < 0) {
             fprintf(stderr, "WARNING: Could not read preferences file 0x%08x from watch.\n", fileno);
         } else {
-            save_buf_to_file(make_tt_filename(fileno, "xml"), "wxb", fbuf, length, 2, true);
+            save_buf_to_file(make_tt_filename(ttd->files->manifest, "xml"), "wxb", fbuf, length, 2, true);
             free(fbuf);
         }
 #endif
 
         if (set_time) {
-            uint32_t fileno = 0x00850000;
-            fprintf(stderr, "Checking watch settings manifest file 0x%08x...\n", fileno);
-            if ((length = tt_read_file(ttd, fileno, debug, &fbuf)) < 0) {
-                fprintf(stderr, "WARNING: Could not read settings manifest file 0x%08x from watch!\n", fileno);
+            fprintf(stderr, "Checking watch settings manifest file 0x%08x...\n", ttd->files->manifest);
+            if ((length = tt_read_file(ttd, ttd->files->manifest, debug, &fbuf)) < 0) {
+                fprintf(stderr, "WARNING: Could not read settings manifest file 0x%08x from watch!\n", ttd->files->manifest);
             } else {
                 // based on ttwatch/libttwatch/libttwatch.h, ttwatch/ttwatch/manifest_definitions.h
                 int32_t *watch_timezone = NULL;
@@ -566,8 +563,8 @@ int main(int argc, const char **argv)
                     if (btohl(*watch_timezone) != lt->tm_gmtoff) {
                         fprintf(stderr, "  Changing timezone from UTC%+d to UTC%+ld.\n", btohl(*watch_timezone), lt->tm_gmtoff);
                         *watch_timezone = htobl(lt->tm_gmtoff);
-                        tt_delete_file(ttd, 0x00850000);
-                        tt_write_file(ttd, 0x00850000, false, fbuf, length, write_delay);
+                        tt_delete_file(ttd, ttd->files->manifest);
+                        tt_write_file(ttd, ttd->files->manifest, false, fbuf, length, write_delay);
                         needs_reboot = true;
                     }
                 }
@@ -577,7 +574,7 @@ int main(int argc, const char **argv)
 
         if (get_activities) {
             uint16_t *list;
-            int n_files = tt_list_sub_files(ttd, 0x00910000, &list);
+            int n_files = tt_list_sub_files(ttd, ttd->files->activity_start, &list);
 
             if (n_files < 0) {
                 fprintf(stderr, "Could not list activity files on watch!\n");
@@ -585,7 +582,7 @@ int main(int argc, const char **argv)
             }
             fprintf(stderr, "Found %d activity files on watch.\n", n_files);
             for (int ii=0; ii<n_files; ii++) {
-                uint32_t fileno = 0x00910000 + list[ii];
+                uint32_t fileno = ttd->files->activity_start + list[ii];
 
                 fprintf(stderr, "  Reading activity file 0x%08X ...\n", fileno);
                 term_title("ttblue: Transferring activity %d/%d", ii+1, n_files);
@@ -669,8 +666,8 @@ int main(int argc, const char **argv)
                             goto fail;
                         } else {
                             fclose (f);
-                            tt_delete_file(ttd, 0x00010100);
-                            result = tt_write_file(ttd, 0x00010100, debug, fbuf, length, write_delay);
+                            tt_delete_file(ttd, ttd->files->quickgps);
+                            result = tt_write_file(ttd, ttd->files->quickgps, debug, fbuf, length, write_delay);
                             free(fbuf);
                             if (result < 0) {
                                 fputs("Failed to send QuickFixGPS update to watch.\n", stderr);

--- a/ttblue.c
+++ b/ttblue.c
@@ -53,12 +53,12 @@ const char *PAIRING_CODE_PROMPT =
     "\n**************************************************\n"
     "Enter 6-digit pairing code shown on device: ";
 
-#define GQF_GPS_URL "http://gpsquickfix.services.tomtom.com/fitness/sifgps.f2p3enc.ee?timestamp=%ld"
-#define GQF_GLONASS_URL "http://gpsquickfix.services.tomtom.com/fitness/sifglo.f2p3enc.ee?timestamp=%ld"
+#define GQF_GPS_URL "https://gpsquickfix.services.tomtom.com/fitness/sifgps.f2p3enc.ee?timestamp=%ld"
+#define GQF_GLONASS_URL "https://gpsquickfix.services.tomtom.com/fitness/sifglo.f2p3enc.ee?timestamp=%ld"
 // Found an alternate source for the ephemeris file: https://github.com/felixge/node-ar-drone/issues/74#issuecomment-25722745
 // This one is nice because the number of days is selectable (3, 7, etc.) although TomTom seems only to
 // accept 3-day version
-#define GQF_GPS_ALT_URL "http://download.parrot.com/ephemerides/packedDifference.f2p3enc.ee?timestamp=%ld"
+#define GQF_GPS_ALT_URL "https://download.parrot.com/ephemerides/packedDifference.f2p3enc.ee?timestamp=%ld"
 
 /**
  * taken from bluez/tools/btgatt-client.c

--- a/ttops.c
+++ b/ttops.c
@@ -95,17 +95,17 @@ tt_device_init(int protocol_version, int fd) {
         d->oldest_tested_firmware = VERSION_TUPLE(1,8,34);
         d->newest_tested_firmware = VERSION_TUPLE(1,8,46);
         d->tested_models = tested_models_v1;
-	d->files = &v1_files;
+        d->files = &v1_files;
         break;
     case 2:
         d->h = &v2_handles;
         d->info = v2_info;
         d->oldest_tested_firmware = VERSION_TUPLE(1,1,19);
         d->newest_tested_firmware = VERSION_TUPLE(1,7,64);
-	// @drkingpo confirmed v1.2.0 works now (see issue #5)
-	// @Grimler91 tested 1.7.62 and 1.7.64.
+        // @drkingpo confirmed v1.2.0 works now (see issue #5)
+        // @Grimler91 tested 1.7.62 and 1.7.64.
         d->tested_models = tested_models_v2;
-	d->files = &v2_files;
+        d->files = &v2_files;
         break;
     default:
         return NULL;

--- a/ttops.c
+++ b/ttops.c
@@ -29,7 +29,7 @@ struct tt_files v1_files = {
 };
 
 struct tt_files v2_files = {
-    .hostname       = 0x00020002,
+    .hostname       = 0x00020003,
     .manifest       = 0x000f20000,
     .activity_start = 0x00910000,
     .gps_status     = 0x00020001,

--- a/ttops.c
+++ b/ttops.c
@@ -54,7 +54,8 @@ struct ble_dev_info v2_info[] = {
     { 0x0044, "model_name" },
     { 0x004a, "model_num" },
     { 0x004c, "firmware" },
-    { 0x0042, "system_id" } // Seems to be set to 0.
+    { 0x0042, "system_id" }, // Seems to be set to 0.
+    { 0 }
 };
 
 #define EXPECTED_MAKER "TomTom Fitness"

--- a/ttops.c
+++ b/ttops.c
@@ -20,6 +20,22 @@
 struct tt_handles v1_handles = { .ppcp=0x0b, .passcode=0x32, .magic=0x35, .cmd_status=0x25, .length=0x28, .transfer=0x2b, .check=0x2e };
 struct tt_handles v2_handles = { .ppcp=0,    .passcode=0x82, .magic=0x85, .cmd_status=0x72, .length=0x75, .transfer=0x78, .check=0x7b };
 
+struct tt_files v1_files = {
+    .hostname       = 0x00020002,
+    .manifest       = 0x000f20000,
+    .activity_start = 0x00910000,
+    .gps_status     = 0x00020001,
+    .quickgps       = 0x00010100
+};
+
+struct tt_files v2_files = {
+    .hostname       = 0x00020002,
+    .manifest       = 0x000f20000,
+    .activity_start = 0x00910000,
+    .gps_status     = 0x00020001,
+    .quickgps       = 0x00010100
+};
+
 struct ble_dev_info v1_info[] = {
     { 0x001e, "maker" },
     { 0x0016, "serial" },
@@ -79,6 +95,7 @@ tt_device_init(int protocol_version, int fd) {
         d->oldest_tested_firmware = VERSION_TUPLE(1,8,34);
         d->newest_tested_firmware = VERSION_TUPLE(1,8,46);
         d->tested_models = tested_models_v1;
+	d->files = &v1_files;
         break;
     case 2:
         d->h = &v2_handles;
@@ -86,6 +103,7 @@ tt_device_init(int protocol_version, int fd) {
         d->oldest_tested_firmware = VERSION_TUPLE(1,1,19);
         d->newest_tested_firmware = VERSION_TUPLE(1,2,0); // @drkingpo confirmed v1.2.0 works now (see issue #5)
         d->tested_models = tested_models_v2;
+	d->files = &v2_files;
         break;
     default:
         return NULL;

--- a/ttops.c
+++ b/ttops.c
@@ -22,7 +22,7 @@ struct tt_handles v2_handles = { .ppcp=0,    .passcode=0x82, .magic=0x85, .cmd_s
 
 struct tt_files v1_files = {
     .hostname       = 0x00020002,
-    .manifest       = 0x000f20000,
+    .manifest       = 0x000f2000,
     .activity_start = 0x00910000,
     .gps_status     = 0x00020001,
     .quickgps       = 0x00010100
@@ -30,7 +30,7 @@ struct tt_files v1_files = {
 
 struct tt_files v2_files = {
     .hostname       = 0x00020003,
-    .manifest       = 0x000f20000,
+    .manifest       = 0x000f2000,
     .activity_start = 0x00910000,
     .gps_status     = 0x00020001,
     .quickgps       = 0x00010100

--- a/ttops.c
+++ b/ttops.c
@@ -215,6 +215,7 @@ tt_authorize(TTDEV *d, uint32_t code, bool new_code)
         magic_bytes = BARRAY( 0x01, 0x19, 0, 0, 0x01, 0x17, 0, 0 );
         if (new_code) {
             att_wrreq(d->fd, 0x0083, &auth_one, sizeof auth_one); // (v1 + 0x50)
+            att_wrreq(d->fd, 0x0088, &auth_one, sizeof auth_one);
             att_wrreq(d->fd, 0x0073, &auth_one, sizeof auth_one); // (v1 + 0x4d)
             att_wrreq(d->fd, 0x007c, &auth_one, sizeof auth_one); // (v1 + 0x4d)
             att_wrreq(d->fd, 0x0076, &auth_one, sizeof auth_one); // (v1 + 0x4d)

--- a/ttops.c
+++ b/ttops.c
@@ -54,12 +54,12 @@ struct ble_dev_info v2_info[] = {
     { 0x0044, "model_name" },
     { 0x004a, "model_num" },
     { 0x004c, "firmware" },
-    { 0 }
+    { 0x0042, "system_id" } // Seems to be set to 0.
 };
 
 #define EXPECTED_MAKER "TomTom Fitness"
 const char *tested_models_v1[] = {"1001","1002","1003","1004",NULL};
-const char *tested_models_v2[] = {"2006","2008",NULL};
+const char *tested_models_v2[] = {"2005","2006","2008",NULL};
 
 const char *FIRMWARE_TOO_OLD =
     "Firmware v%s is too old; at least v%s is required\n"
@@ -68,8 +68,8 @@ const char *FIRMWARE_TOO_OLD =
     "* Use USB cable and ttwatch to update your firmware:\n"
     "\thttp://github.com/ryanbinns/ttwatch\n";
 
-const char *FIRMWARE_NOTES_v1 = "https://support.tomtom.com/app/release_notes/type/watches";
-const char *FIRMWARE_NOTES_v2 = "https://support.tomtom.com/app/release_notes/type/watch2015";
+const char *FIRMWARE_NOTES_v1 = "https://us.support.tomtom.com/app/release_notes/type/watches";
+const char *FIRMWARE_NOTES_v2 = "https://us.support.tomtom.com/app/release_notes/type/watch2015";
 
 const char *FIRMWARE_UNTESTED =
     "WARNING: Firmware v%s has not been tested with ttblue\n"
@@ -101,7 +101,9 @@ tt_device_init(int protocol_version, int fd) {
         d->h = &v2_handles;
         d->info = v2_info;
         d->oldest_tested_firmware = VERSION_TUPLE(1,1,19);
-        d->newest_tested_firmware = VERSION_TUPLE(1,2,0); // @drkingpo confirmed v1.2.0 works now (see issue #5)
+        d->newest_tested_firmware = VERSION_TUPLE(1,7,64);
+	// @drkingpo confirmed v1.2.0 works now (see issue #5)
+	// @Grimler91 tested 1.7.62 and 1.7.64.
         d->tested_models = tested_models_v2;
 	d->files = &v2_files;
         break;
@@ -209,32 +211,32 @@ tt_authorize(TTDEV *d, uint32_t code, bool new_code)
         }
         return EXPECT_uint8(d, d->h->passcode, 1);
     case 2:
-        // Android software, from @drkingpo's log
-        magic_bytes = BARRAY( 0x01, 0x15, 0, 0, 0x01, 0x1f, 0, 0 );
+        // Android software, from @drkingpo's log, updated by @Grimler91 for 1.7.64
+        magic_bytes = BARRAY( 0x01, 0x19, 0, 0, 0x01, 0x17, 0, 0 );
         if (new_code) {
-            att_write(d->fd, 0x0083, &auth_one, sizeof auth_one); // from @drkingpo's btsnoop_hci.log (v1 + 0x50)
-            att_wrreq(d->fd, 0x0073, &auth_one, sizeof auth_one); // from @drkingpo's btsnoop_hci.log (v1 + 0x4d, and CHANGED FROM WRITE TO WRREQ
-            att_write(d->fd, 0x007c, &auth_one, sizeof auth_one); // from @drkingpo's btsnoop_hci.log (v1 + 0x4d)
-            att_write(d->fd, 0x0076, &auth_one, sizeof auth_one); // from @drkingpo's btsnoop_hci.log (v1 + 0x4d)
-            att_write(d->fd, 0x0079, &auth_one, sizeof auth_one); // from @drkingpo's btsnoop_hci.log (v1 + 0x4d)
-            att_wrreq(d->fd, d->h->magic, magic_bytes, sizeof magic_bytes); // from @drkingpo's btsnoop_hci.log (v1 + 0x50)
-            att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode); // from @drkingpo's btsnoop_hci.log (v1 + 0x50)
+            att_wrreq(d->fd, 0x0083, &auth_one, sizeof auth_one); // (v1 + 0x50)
+            att_wrreq(d->fd, 0x0073, &auth_one, sizeof auth_one); // (v1 + 0x4d)
+            att_wrreq(d->fd, 0x007c, &auth_one, sizeof auth_one); // (v1 + 0x4d)
+            att_wrreq(d->fd, 0x0076, &auth_one, sizeof auth_one); // (v1 + 0x4d)
+            att_wrreq(d->fd, 0x0079, &auth_one, sizeof auth_one); // (v1 + 0x4d)
+            att_wrreq(d->fd, d->h->magic, magic_bytes, sizeof magic_bytes); // (v1 + 0x50)
+            att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode); //  (v1 + 0x50)
         } else {
             // based on btsnoop_hci.log from @drkingpo
-            att_write(d->fd, 0x0083, &auth_one, sizeof auth_one); // from @drkingpo's btsnoop_hci.log (v1 + 0x50)
-            att_wrreq(d->fd, d->h->magic, magic_bytes, sizeof magic_bytes); // from @drkingpo's btsnoop_hci.log (v1 + 0x50)
-            att_wrreq(d->fd, 0x0073, &auth_one, sizeof auth_one); // from @drkingpo's btsnoop_hci.log (v1 + 0x4d, and CHANGED FROM WRITE TO WRREQ
-            att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode); // from @drkingpo's btsnoop_hci.log (v1 + 0x50)
+            att_wrreq(d->fd, 0x0083, &auth_one, sizeof auth_one); // (v1 + 0x50)
+            att_wrreq(d->fd, d->h->magic, magic_bytes, sizeof magic_bytes); // (v1 + 0x50)
+            att_wrreq(d->fd, 0x0073, &auth_one, sizeof auth_one); // (v1 + 0x4d)
+            att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode); // (v1 + 0x50)
 
             int res = EXPECT_uint8(d, d->h->passcode, 1);
             if (res < 0)
                 return res;
 
-            att_write(d->fd, 0x007c, &auth_one, sizeof auth_one); // from @drkingpo's btsnoop_hci.log (v1 + 0x4d)
-            att_write(d->fd, 0x0076, &auth_one, sizeof auth_one); // from @drkingpo's btsnoop_hci.log (v1 + 0x4d)
-            att_write(d->fd, 0x0079, &auth_one, sizeof auth_one); // from @drkingpo's btsnoop_hci.log (v1 + 0x4d)
-            att_wrreq(d->fd, d->h->magic, magic_bytes, sizeof magic_bytes); // from @drkingpo's btsnoop_hci.log (v1 + 0x50)
-            att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode); // from @drkingpo's btsnoop_hci.log (v1 + 0x50)
+            att_wrreq(d->fd, 0x007c, &auth_one, sizeof auth_one); // (v1 + 0x4d)
+            att_wrreq(d->fd, 0x0076, &auth_one, sizeof auth_one); // (v1 + 0x4d)
+            att_wrreq(d->fd, 0x0079, &auth_one, sizeof auth_one); // (v1 + 0x4d)
+            att_wrreq(d->fd, d->h->magic, magic_bytes, sizeof magic_bytes); // (v1 + 0x50)
+            att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode); //  (v1 + 0x50)
         }
         return EXPECT_uint8(d, d->h->passcode, 1);
     }
@@ -347,7 +349,7 @@ tt_write_file(TTDEV *d, uint32_t fileno, int debug, const uint8_t *buf, uint32_t
        return -1;
 
     uint32_t flen = htobl(length);
-    att_wrreq(d->fd, d->h->length, &flen, sizeof flen);
+    att_write(d->fd, d->h->length, &flen, sizeof flen);
 
     const uint8_t *iptr = buf;
     const uint8_t *end = iptr+length;

--- a/ttops.h
+++ b/ttops.h
@@ -6,6 +6,8 @@
 
 struct tt_handles { uint16_t ppcp, passcode, magic, cmd_status, length, transfer, check; };
 
+struct tt_files { uint32_t hostname, manifest, activity_start, gps_status, quickgps; };
+
 struct ble_dev_info {
     uint16_t handle;
     const char *name;
@@ -21,6 +23,7 @@ typedef struct ttdev {
 
     struct version_tuple oldest_tested_firmware, newest_tested_firmware;
     const char **tested_models;
+    struct tt_files *files;
 } TTDEV;
 
 #include "util.h"


### PR DESCRIPTION
I'm looking into https://github.com/dlenski/ttblue/issues/7 and had to update the pairing sequence&magic bytes to make it work with fw v1.7.64. 

Note that pairing works without the write->wrreq changes I have done, so these are mostly cosmetic, to make pairing identical to with official app.
And on that note, pairing and re-pairing seem to be identical on my phone. It seems that numerous variants are all valid (write or wrreq, with or without the new 0x88 wrreq or in different orders) but I haven't investigated it further. 
I will open a PR later and suggest that the re-pair case is removed, for the v2 case. I suspect that it can also be removed for the v1 case, but I don't have a watch with which I can capture traffic and test it.

I also moved file addresses to a tt_files struct, since the addresses change over time/versions. 
The hostname file (0x00020002) has moved to 0x00020003 for my v2, is it still 0x00020002 for a v1 watch?
I think it would also be a good idea to store all handles in a similar struct but I haven't implemented it yet.

I also, lastly, shortened some of the comments in the v2 pairing code to avoid long lines.
That was all in this round of commits I think!