### PR TITLE
Pairing simplification

### DIFF
--- a/ttblue.c
+++ b/ttblue.c
@@ -512,7 +512,7 @@ int main(int argc, const char **argv)
         }
 
         // authorize with the device
-        if (tt_authorize(ttd, dev_code, new_pair) < 0) {
+        if (tt_authorize(ttd, dev_code) < 0) {
             fprintf(stderr, "Device didn't accept pairing code %d.\n", dev_code);
             if (first) goto fatal; else goto fail;
         }

--- a/ttops.c
+++ b/ttops.c
@@ -96,7 +96,7 @@ tt_device_init(int protocol_version, int fd) {
         d->h = &v1_handles;
         d->info = v1_info;
         d->oldest_tested_firmware = VERSION_TUPLE(1,8,34);
-        d->newest_tested_firmware = VERSION_TUPLE(1,8,46);
+        d->newest_tested_firmware = VERSION_TUPLE(1,8,52);
         d->tested_models = tested_models_v1;
         d->files = &v1_files;
         break;
@@ -186,29 +186,28 @@ tt_authorize(TTDEV *d, uint32_t code, bool new_code)
 
     switch (d->protocol_version) {
     case 1:
-        // TomTom MySports 2.1.13-a3eb49a for Android
-        magic_bytes = BARRAY( 0x01, 0x16, 0, 0, 0x01, 0x29, 0, 0 );
+        magic_bytes = BARRAY( 0x01, 0x19, 0, 0, 0x01, 0x17, 0, 0 );
         if (new_code) {
-            att_write(d->fd, 0x0033, &auth_one, sizeof auth_one);
-            att_write(d->fd, 0x0026, &auth_one, sizeof auth_one);
-            att_write(d->fd, 0x002f, &auth_one, sizeof auth_one);
-            att_write(d->fd, 0x0029, &auth_one, sizeof auth_one);
-            att_write(d->fd, 0x002c, &auth_one, sizeof auth_one);
+            att_wrreq(d->fd, 0x0033, &auth_one, sizeof auth_one);
+            att_wrreq(d->fd, 0x0026, &auth_one, sizeof auth_one);
+            att_wrreq(d->fd, 0x002f, &auth_one, sizeof auth_one);
+            att_wrreq(d->fd, 0x0029, &auth_one, sizeof auth_one);
+            att_wrreq(d->fd, 0x002c, &auth_one, sizeof auth_one);
             att_wrreq(d->fd, d->h->magic, magic_bytes, 8);
             att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode);
         } else {
-            att_write(d->fd, 0x0033, &auth_one, sizeof auth_one);
+            att_wrreq(d->fd, 0x0033, &auth_one, sizeof auth_one);
             att_wrreq(d->fd, d->h->magic, magic_bytes, sizeof magic_bytes);
-            att_write(d->fd, 0x0026, &auth_one, sizeof auth_one);
+            att_wrreq(d->fd, 0x0026, &auth_one, sizeof auth_one);
             att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode);
 
             int res = EXPECT_uint8(d, d->h->passcode, 1);
             if (res < 0)
                 return res;
 
-            att_write(d->fd, 0x002f, &auth_one, sizeof auth_one);
-            att_write(d->fd, 0x0029, &auth_one, sizeof auth_one);
-            att_write(d->fd, 0x002c, &auth_one, sizeof auth_one);
+            att_wrreq(d->fd, 0x002f, &auth_one, sizeof auth_one);
+            att_wrreq(d->fd, 0x0029, &auth_one, sizeof auth_one);
+            att_wrreq(d->fd, 0x002c, &auth_one, sizeof auth_one);
             att_wrreq(d->fd, d->h->magic, magic_bytes, 8);
             att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode);
         }

--- a/ttops.c
+++ b/ttops.c
@@ -192,22 +192,21 @@ tt_authorize(TTDEV *d, uint32_t code)
         att_wrreq(d->fd, 0x002f, &auth_one, sizeof auth_one);
         att_wrreq(d->fd, 0x0029, &auth_one, sizeof auth_one);
         att_wrreq(d->fd, 0x002c, &auth_one, sizeof auth_one);
-        att_wrreq(d->fd, d->h->magic, magic_bytes, 8);
-        att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode);
-        return EXPECT_uint8(d, d->h->passcode, 1);
+        break;
     case 2:
-        // Android software, from @drkingpo's log, updated by @Grimler91 for 1.7.64
         att_wrreq(d->fd, 0x0083, &auth_one, sizeof auth_one); // (v1 + 0x50)
         att_wrreq(d->fd, 0x0088, &auth_one, sizeof auth_one);
         att_wrreq(d->fd, 0x0073, &auth_one, sizeof auth_one); // (v1 + 0x4d)
         att_wrreq(d->fd, 0x007c, &auth_one, sizeof auth_one); // (v1 + 0x4d)
         att_wrreq(d->fd, 0x0076, &auth_one, sizeof auth_one); // (v1 + 0x4d)
         att_wrreq(d->fd, 0x0079, &auth_one, sizeof auth_one); // (v1 + 0x4d)
-        att_wrreq(d->fd, d->h->magic, magic_bytes, 8); // (v1 + 0x50)
-        att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode); //  (v1 + 0x50)
-        return EXPECT_uint8(d, d->h->passcode, 1);
+        break;
+    default:
+        return -2;
     }
-    return -2;
+    att_wrreq(d->fd, d->h->magic, magic_bytes, 8);
+    att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode);
+    return EXPECT_uint8(d, d->h->passcode, 1);
 }
 
 int

--- a/ttops.c
+++ b/ttops.c
@@ -177,70 +177,34 @@ tt_check_device_version(TTDEV *d, bool warning)
 /****************************************************************************/
 
 int
-tt_authorize(TTDEV *d, uint32_t code, bool new_code)
+tt_authorize(TTDEV *d, uint32_t code)
 {
     // authorize with the device
     const uint16_t auth_one = btohs(0x0001);
     uint32_t bcode = htobl(code);
     const uint8_t *magic_bytes;
+    magic_bytes = BARRAY( 0x01, 0x19, 0, 0, 0x01, 0x17, 0, 0 );
 
     switch (d->protocol_version) {
     case 1:
-        magic_bytes = BARRAY( 0x01, 0x19, 0, 0, 0x01, 0x17, 0, 0 );
-        if (new_code) {
-            att_wrreq(d->fd, 0x0033, &auth_one, sizeof auth_one);
-            att_wrreq(d->fd, 0x0026, &auth_one, sizeof auth_one);
-            att_wrreq(d->fd, 0x002f, &auth_one, sizeof auth_one);
-            att_wrreq(d->fd, 0x0029, &auth_one, sizeof auth_one);
-            att_wrreq(d->fd, 0x002c, &auth_one, sizeof auth_one);
-            att_wrreq(d->fd, d->h->magic, magic_bytes, 8);
-            att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode);
-        } else {
-            att_wrreq(d->fd, 0x0033, &auth_one, sizeof auth_one);
-            att_wrreq(d->fd, d->h->magic, magic_bytes, sizeof magic_bytes);
-            att_wrreq(d->fd, 0x0026, &auth_one, sizeof auth_one);
-            att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode);
-
-            int res = EXPECT_uint8(d, d->h->passcode, 1);
-            if (res < 0)
-                return res;
-
-            att_wrreq(d->fd, 0x002f, &auth_one, sizeof auth_one);
-            att_wrreq(d->fd, 0x0029, &auth_one, sizeof auth_one);
-            att_wrreq(d->fd, 0x002c, &auth_one, sizeof auth_one);
-            att_wrreq(d->fd, d->h->magic, magic_bytes, 8);
-            att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode);
-        }
+        att_wrreq(d->fd, 0x0033, &auth_one, sizeof auth_one);
+        att_wrreq(d->fd, 0x0026, &auth_one, sizeof auth_one);
+        att_wrreq(d->fd, 0x002f, &auth_one, sizeof auth_one);
+        att_wrreq(d->fd, 0x0029, &auth_one, sizeof auth_one);
+        att_wrreq(d->fd, 0x002c, &auth_one, sizeof auth_one);
+        att_wrreq(d->fd, d->h->magic, magic_bytes, 8);
+        att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode);
         return EXPECT_uint8(d, d->h->passcode, 1);
     case 2:
         // Android software, from @drkingpo's log, updated by @Grimler91 for 1.7.64
-        magic_bytes = BARRAY( 0x01, 0x19, 0, 0, 0x01, 0x17, 0, 0 );
-        if (new_code) {
-            att_wrreq(d->fd, 0x0083, &auth_one, sizeof auth_one); // (v1 + 0x50)
-            att_wrreq(d->fd, 0x0088, &auth_one, sizeof auth_one);
-            att_wrreq(d->fd, 0x0073, &auth_one, sizeof auth_one); // (v1 + 0x4d)
-            att_wrreq(d->fd, 0x007c, &auth_one, sizeof auth_one); // (v1 + 0x4d)
-            att_wrreq(d->fd, 0x0076, &auth_one, sizeof auth_one); // (v1 + 0x4d)
-            att_wrreq(d->fd, 0x0079, &auth_one, sizeof auth_one); // (v1 + 0x4d)
-            att_wrreq(d->fd, d->h->magic, magic_bytes, sizeof magic_bytes); // (v1 + 0x50)
-            att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode); //  (v1 + 0x50)
-        } else {
-            // based on btsnoop_hci.log from @drkingpo
-            att_wrreq(d->fd, 0x0083, &auth_one, sizeof auth_one); // (v1 + 0x50)
-            att_wrreq(d->fd, d->h->magic, magic_bytes, sizeof magic_bytes); // (v1 + 0x50)
-            att_wrreq(d->fd, 0x0073, &auth_one, sizeof auth_one); // (v1 + 0x4d)
-            att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode); // (v1 + 0x50)
-
-            int res = EXPECT_uint8(d, d->h->passcode, 1);
-            if (res < 0)
-                return res;
-
-            att_wrreq(d->fd, 0x007c, &auth_one, sizeof auth_one); // (v1 + 0x4d)
-            att_wrreq(d->fd, 0x0076, &auth_one, sizeof auth_one); // (v1 + 0x4d)
-            att_wrreq(d->fd, 0x0079, &auth_one, sizeof auth_one); // (v1 + 0x4d)
-            att_wrreq(d->fd, d->h->magic, magic_bytes, sizeof magic_bytes); // (v1 + 0x50)
-            att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode); //  (v1 + 0x50)
-        }
+        att_wrreq(d->fd, 0x0083, &auth_one, sizeof auth_one); // (v1 + 0x50)
+        att_wrreq(d->fd, 0x0088, &auth_one, sizeof auth_one);
+        att_wrreq(d->fd, 0x0073, &auth_one, sizeof auth_one); // (v1 + 0x4d)
+        att_wrreq(d->fd, 0x007c, &auth_one, sizeof auth_one); // (v1 + 0x4d)
+        att_wrreq(d->fd, 0x0076, &auth_one, sizeof auth_one); // (v1 + 0x4d)
+        att_wrreq(d->fd, 0x0079, &auth_one, sizeof auth_one); // (v1 + 0x4d)
+        att_wrreq(d->fd, d->h->magic, magic_bytes, 8); // (v1 + 0x50)
+        att_wrreq(d->fd, d->h->passcode, &bcode, sizeof bcode); //  (v1 + 0x50)
         return EXPECT_uint8(d, d->h->passcode, 1);
     }
     return -2;

--- a/ttops.c
+++ b/ttops.c
@@ -182,8 +182,7 @@ tt_authorize(TTDEV *d, uint32_t code)
     // authorize with the device
     const uint16_t auth_one = btohs(0x0001);
     uint32_t bcode = htobl(code);
-    const uint8_t *magic_bytes;
-    magic_bytes = BARRAY( 0x01, 0x19, 0, 0, 0x01, 0x17, 0, 0 );
+    const uint8_t *magic_bytes = BARRAY( 0x01, 0x19, 0, 0, 0x01, 0x17, 0, 0 );
 
     switch (d->protocol_version) {
     case 1:

--- a/ttops.h
+++ b/ttops.h
@@ -31,7 +31,7 @@ typedef struct ttdev {
 TTDEV *tt_device_init(int protocol_version, int fd);
 bool tt_device_done(TTDEV *d);
 struct ble_dev_info *tt_check_device_version(TTDEV *d, bool warning);
-int tt_authorize(TTDEV *d, uint32_t code, bool new_code);
+int tt_authorize(TTDEV *d, uint32_t code);
 int tt_read_file(TTDEV *d, uint32_t fileno, int debug, uint8_t **buf);
 int tt_write_file(TTDEV *d, uint32_t fileno, int debug, const uint8_t *buf, uint32_t length, uint32_t write_delay);
 int tt_delete_file(TTDEV *d, uint32_t fileno);


### PR DESCRIPTION
I haven't been able to capture a re-auth sequence for v1 or v2 devices so this PR removes it and simplifies the pairing sequence a bit. 

The old re-auth sequence work however, for both watch versions, so the only real reason for removing it is to match the android app traffic.

I guess this PR might conflict with https://github.com/dlenski/ttblue/pull/13/files, I'll rebase one of them if the other is merged.